### PR TITLE
cut&paste oversight; no `bootstrap` CLI for `gwen`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,4 @@ COPY . .
 EXPOSE 5000
 
 CMD \
-    flask bootstrap && \
     gunicorn --bind "0.0.0.0:${P_PORT:-5000}" ${FLASK_APP}


### PR DESCRIPTION
This is preventing the service from starting, when not running in development mode.