### PR TITLE
special handling for extra whitespace in name fields

### DIFF
--- a/gwen/models/scrub.py
+++ b/gwen/models/scrub.py
@@ -84,9 +84,16 @@ class ScrubMap(object):
         # taking least sig digits isn't guaranteed unique - use more as needed
         digits = 2
         full_hash = str(hash(value))
+
+        def first_letter(letter):
+            if letter == " ":
+                return "_"
+            return letter
+
         while True:
             # maintain first letter and append needed len of hash to keep unique
-            hashed = value[0] + full_hash[-digits:]
+            first = first_letter(value[0])
+            hashed = first + full_hash[-digits:]
             if hashed not in self.map.values():
                 return hashed
             digits += 1
@@ -113,6 +120,10 @@ class ScrubMap(object):
                 tokens = value.split(" ")
                 hashed_tokens = []
                 for token in tokens:
+                    # empty strings in tokens imply extra or embedded white space
+                    # retain to map uniquely as needed
+                    if token == "":
+                        token = " "
                     if token not in self.map:
                         self.map[token] = self.hash_string(token)
                     hashed_tokens.append(self.map[token])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -47,6 +47,17 @@ def test_name_case():
     assert len(sm.map) == 1
 
 
+def test_names_extra_whitespace():
+    full_name = "first  last"
+    sm = ScrubMap()
+    full_hash = sm.clean(full_name)
+    tokenized = []
+    for i in ("first", " ", "last"):
+        tokenized.append(sm.clean(i))
+
+    assert full_hash == " ".join(tokenized)
+
+
 def test_tokenized_name():
     full_name = "first last"
     sm = ScrubMap()


### PR DESCRIPTION
need to retain extra white space at the end of a name field, or within.

requires special checks, and introduces a slightly misleading gap when assembling tokens, but we can't know which field (in a <first_name><space><space><last_name> pattern) the space belongs to.

Example results (note extra space between first & last:

```
'first': 'f49'
' ': '_43'  # single space character
'last': 'l09'
'first last':'f49 l09'  # single space between
'first  last': 'f49 _43 l09'  # double space between
```